### PR TITLE
fix: sync schema.sql with app by dropping obsolete goal term column

### DIFF
--- a/supabase/README.md
+++ b/supabase/README.md
@@ -5,15 +5,21 @@
 - Save the project URL and anon key for later.
 
 ## 2. Run the SQL files
-Run these in the Supabase SQL editor in order:
+
+### Fresh setup
+`supabase/schema.sql` already reflects the current data model, so a new project only needs these three, in order:
 1. `supabase/schema.sql`
 2. `supabase/policies.sql`
 3. `supabase/seed.sql`
-4. `supabase/migrations/20250120_add_goal_outcome.sql` (if upgrading an existing DB)
-5. `supabase/migrations/20250120_remove_duration.sql` (if upgrading an existing DB)
-6. `supabase/migrations/20250120_add_tags_fields.sql` (if upgrading an existing DB)
-7. `supabase/migrations/20250120_fix_categories_unique.sql` (if upgrading an existing DB)
-8. `supabase/migrations/20260124_add_user_settings.sql` (if upgrading an existing DB)
+
+### Upgrading an existing DB
+If you set up the database before these changes landed, run the migrations that apply to you, in order:
+1. `supabase/migrations/20250120_add_goal_outcome.sql`
+2. `supabase/migrations/20250120_remove_duration.sql`
+3. `supabase/migrations/20250120_add_tags_fields.sql`
+4. `supabase/migrations/20250120_fix_categories_unique.sql`
+5. `supabase/migrations/20260122_remove_goal_term.sql`
+6. `supabase/migrations/20260124_add_user_settings.sql`
 
 ## 3. Configure Auth providers
 - Enable Google provider.

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,12 +1,5 @@
 do $$
 begin
-  if not exists (select 1 from pg_type where typname = 'goal_term') then
-    create type goal_term as enum ('short', 'long');
-  end if;
-end $$;
-
-do $$
-begin
   if not exists (select 1 from pg_type where typname = 'goal_outcome') then
     create type goal_outcome as enum ('passed', 'failed');
   end if;
@@ -16,7 +9,6 @@ create table if not exists public.goals (
   id uuid primary key default gen_random_uuid(),
   user_id uuid not null references auth.users(id) on delete cascade,
   title text not null,
-  term goal_term not null,
   outcome goal_outcome,
   created_at timestamptz not null default now(),
   end_at timestamptz


### PR DESCRIPTION
schema.sql still created goals.term (goal_term not null) but the app never inserts it, so a fresh DB setup failed every goal insert. The migration that drops it was also missing from the setup README.

- Remove goal_term enum and term column from schema.sql
- Add 20260122_remove_goal_term.sql to README and split fresh-setup from upgrade migration steps