### PR TITLE
fix: drop overly-permissive categories_read_all RLS policy

### DIFF
--- a/supabase/policies.sql
+++ b/supabase/policies.sql
@@ -67,6 +67,7 @@ using (
 );
 
 alter table public.categories enable row level security;
+drop policy if exists categories_read_all on public.categories;
 drop policy if exists categories_read_own_or_default on public.categories;
 drop policy if exists categories_insert_own on public.categories;
 drop policy if exists categories_update_own on public.categories;


### PR DESCRIPTION
Production had a stray SELECT policy on public.categories with USING (true), which OR-combined with categories_read_own_or_default to make every category row world-readable — exposing other users' custom category names/descriptions to any signed-in or anonymous visitor.

Add a drop for it to policies.sql so re-running the file removes it and leaves categories_read_own_or_default (own + shared defaults) as the only SELECT rule.