### PR TITLE
refactor: move goal and tag database access into lib/

### DIFF
--- a/app/__tests__/goals-data.test.ts
+++ b/app/__tests__/goals-data.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const from = vi.fn();
+vi.mock("@/lib/supabaseClient", () => ({ supabase: { from: (...args: unknown[]) => from(...args) } }));
+
+const { createGoal, mapGoalRow, updateGoal } = await import("@/lib/goals");
+
+/** Minimal stand-in for the chained query builder, resolving to `result`. */
+const builder = (result: unknown) => {
+  const chain: Record<string, unknown> = {};
+  ["insert", "update", "delete", "select", "eq", "order", "is"].forEach((key) => {
+    chain[key] = vi.fn(() => chain);
+  });
+  chain.single = vi.fn(() => Promise.resolve(result));
+  chain.then = (resolve: (value: unknown) => unknown) =>
+    Promise.resolve(result).then(resolve);
+  return chain;
+};
+
+beforeEach(() => {
+  from.mockReset();
+});
+
+describe("mapGoalRow", () => {
+  it("flattens the nested tag join into names and ids", () => {
+    const goal = mapGoalRow({
+      id: "g1",
+      title: "Ship it",
+      created_at: "2026-03-14T12:00:00Z",
+      end_at: null,
+      outcome: "passed",
+      goal_categories: [
+        { category_id: "c1", categories: { name: "Health" } },
+        { category_id: "c2", categories: [{ name: "Career" }] },
+      ],
+    });
+
+    expect(goal).toMatchObject({
+      id: "g1",
+      title: "Ship it",
+      outcome: "passed",
+      endAt: undefined,
+      categoryIds: ["c1", "c2"],
+      categories: ["Health", "Career"],
+    });
+  });
+
+  it("tolerates a goal with no tag rows", () => {
+    const goal = mapGoalRow({
+      id: "g2",
+      title: "Bare",
+      created_at: "2026-03-14T12:00:00Z",
+    });
+    expect(goal.categories).toEqual([]);
+    expect(goal.categoryIds).toEqual([]);
+  });
+
+  it("drops join rows whose category went missing", () => {
+    const goal = mapGoalRow({
+      id: "g3",
+      title: "Partial",
+      created_at: "2026-03-14T12:00:00Z",
+      goal_categories: [
+        { category_id: "c1", categories: null },
+        { category_id: null, categories: { name: "Health" } },
+      ],
+    });
+    expect(goal.categories).toEqual(["Health"]);
+    expect(goal.categoryIds).toEqual(["c1"]);
+  });
+});
+
+describe("createGoal", () => {
+  const savedGoal = {
+    data: {
+      id: "g1",
+      title: "Ship it",
+      outcome: null,
+      created_at: "2026-03-14T12:00:00Z",
+      end_at: null,
+    },
+    error: null,
+  };
+
+  const params = {
+    userId: "u1",
+    title: "Ship it",
+    createdAt: "2026-03-14T12:00:00Z",
+    endAt: null,
+    categoryIds: ["c1"],
+    categoryNames: ["Health"],
+    linkCategories: true,
+  };
+
+  it("reports the tags when the links are written", async () => {
+    from
+      .mockReturnValueOnce(builder(savedGoal))
+      .mockReturnValueOnce(builder({ error: null }));
+
+    const { data, error } = await createGoal(params);
+
+    expect(error).toBeNull();
+    expect(data?.categoriesLinked).toBe(true);
+    expect(data?.goal.categories).toEqual(["Health"]);
+    expect(data?.goal.categoryIds).toEqual(["c1"]);
+  });
+
+  it("keeps the goal but reports no tags when the links fail", async () => {
+    from
+      .mockReturnValueOnce(builder(savedGoal))
+      .mockReturnValueOnce(builder({ error: { message: "rls denied" } }));
+
+    const { data, error } = await createGoal(params);
+
+    // The goal really was written, so it is still returned...
+    expect(error).toBeNull();
+    expect(data?.goal.id).toBe("g1");
+    // ...but the tags never landed, so local state must not claim them.
+    expect(data?.categoriesLinked).toBe(false);
+    expect(data?.categoryError).toBe("rls denied");
+    expect(data?.goal.categories).toEqual([]);
+    expect(data?.goal.categoryIds).toEqual([]);
+  });
+
+  it("surfaces a failed goal insert as an error", async () => {
+    from.mockReturnValueOnce(builder({ data: null, error: { message: "nope" } }));
+
+    const { data, error } = await createGoal(params);
+
+    expect(data).toBeNull();
+    expect(error).toBe("nope");
+  });
+});
+
+describe("updateGoal", () => {
+  const params = {
+    goalId: "g1",
+    title: "Ship it",
+    outcome: null,
+    endAt: null,
+    categoryIds: ["c1"],
+    syncCategories: true,
+  };
+
+  it("reports linked when the tag rows are replaced cleanly", async () => {
+    from
+      .mockReturnValueOnce(builder({ error: null })) // goals update
+      .mockReturnValueOnce(builder({ error: null })) // delete old links
+      .mockReturnValueOnce(builder({ error: null })); // insert new links
+
+    const { data } = await updateGoal(params);
+    expect(data?.categoriesLinked).toBe(true);
+  });
+
+  it("reports unlinked when the old links were cleared but the new ones failed", async () => {
+    from
+      .mockReturnValueOnce(builder({ error: null }))
+      .mockReturnValueOnce(builder({ error: null }))
+      .mockReturnValueOnce(builder({ error: { message: "insert failed" } }));
+
+    const { data } = await updateGoal(params);
+
+    // The delete already happened, so the goal genuinely has no tags now.
+    expect(data?.categoriesLinked).toBe(false);
+    expect(data?.categoryError).toBe("insert failed");
+  });
+
+  it("skips tag work entirely when syncing is off", async () => {
+    from.mockReturnValueOnce(builder({ error: null }));
+
+    const { data } = await updateGoal({ ...params, syncCategories: false });
+
+    expect(from).toHaveBeenCalledTimes(1);
+    expect(data?.categoriesLinked).toBe(true);
+  });
+});

--- a/app/__tests__/tag-helpers.test.ts
+++ b/app/__tests__/tag-helpers.test.ts
@@ -1,4 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+// lib/tags also holds the Supabase-backed calls; the helpers under test are
+// pure, so stub the client rather than warning about missing env vars.
+vi.mock("@/lib/supabaseClient", () => ({ supabase: null }));
+
 import {
   DEFAULT_CATEGORIES,
   DEFAULT_TAG_NAMES,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,7 +32,14 @@ import {
   toLocalInputValue,
 } from "@/lib/date";
 import { buildDailyGrid } from "@/lib/heatmap";
-import { DEFAULT_CATEGORIES, DEFAULT_TAG_SEED } from "@/lib/tags";
+import {
+  createGoal,
+  deleteGoal,
+  fetchGoals,
+  setGoalOutcome,
+  updateGoal,
+} from "@/lib/goals";
+import { DEFAULT_CATEGORIES, fetchTagsForUser } from "@/lib/tags";
 import { Activity } from "lucide-react";
 
 const HOVER_CARD_DELAY = 800;
@@ -120,56 +127,16 @@ export default function Home() {
     }
 
     const loadCategories = async () => {
-      if (!supabase || !session) return;
+      if (!session) return;
       setCategoriesLoaded(false);
-      const { data, error } = await supabase
-        .from("categories")
-        .select("id, name, description, user_id")
-        .eq("user_id", session.user.id)
-        .order("name");
-      if (error) {
+      const { data, error } = await fetchTagsForUser(session.user.id);
+
+      // No usable tags from the database — fall back to the built-in list so
+      // the picker still works, and flag it so we never write tag links.
+      if (error || !data || data.length === 0) {
         setCategories(DEFAULT_CATEGORIES);
         setCategoriesFromDb(false);
         setCategoriesUserId(null);
-        setCategoriesLoaded(true);
-        return;
-      }
-
-      if (!data || data.length === 0) {
-        const { data: defaults } = await supabase
-          .from("categories")
-          .select("name, description")
-          .is("user_id", null)
-          .order("name");
-
-        const seed =
-          defaults && defaults.length > 0 ? defaults : DEFAULT_TAG_SEED;
-
-        if (seed.length > 0) {
-          await supabase.from("categories").insert(
-            seed.map((item) => ({
-              user_id: session.user.id,
-              name: item.name,
-              description: item.description ?? null,
-            })),
-          );
-        }
-
-        const { data: reloaded } = await supabase
-          .from("categories")
-          .select("id, name, description, user_id")
-          .eq("user_id", session.user.id)
-          .order("name");
-        if (!reloaded || reloaded.length === 0) {
-          setCategories(DEFAULT_CATEGORIES);
-          setCategoriesFromDb(false);
-          setCategoriesUserId(null);
-          setCategoriesLoaded(true);
-          return;
-        }
-        setCategories(reloaded);
-        setCategoriesFromDb(true);
-        setCategoriesUserId(session.user.id);
         setCategoriesLoaded(true);
         return;
       }
@@ -215,47 +182,18 @@ export default function Home() {
     }
 
     const loadGoals = async () => {
-      if (!supabase || !session) return;
+      if (!session) return;
       setGoalsLoading(true);
       setGoalsLoaded(false);
       setGoalsError(null);
-      const { data, error } = await supabase
-        .from("goals")
-        .select(
-          "id, title, outcome, created_at, end_at, goal_categories(category_id, categories(name))",
-        )
-        .order("created_at", { ascending: false });
+      const { data, error } = await fetchGoals();
       if (error || !data) {
-        setGoalsError(error?.message ?? "Unable to load goals.");
+        setGoalsError(error ?? "Unable to load goals.");
         setGoalsLoading(false);
         setGoalsLoaded(true);
         return;
       }
-      const mapped: Goal[] = data.map((goal) => ({
-        id: goal.id,
-        title: goal.title,
-        outcome: goal.outcome ?? undefined,
-        createdAt: goal.created_at,
-        endAt: goal.end_at ?? undefined,
-        categoryIds: (goal.goal_categories ?? [])
-          .map((item) => item.category_id)
-          .filter((id): id is string => typeof id === "string"),
-        categories: (goal.goal_categories ?? [])
-          .map((item) => {
-            const categories = item.categories as
-              | { name?: string }
-              | { name?: string }[]
-              | null
-              | undefined;
-            if (!categories) return null;
-            if (Array.isArray(categories)) {
-              return categories[0]?.name ?? null;
-            }
-            return categories.name ?? null;
-          })
-          .filter((name): name is string => typeof name === "string"),
-      }));
-      setGoals(mapped);
+      setGoals(data);
       setGoalsLoading(false);
       setGoalsLoaded(true);
       setGoalsUserId(session.user.id);
@@ -428,54 +366,34 @@ export default function Home() {
     }
 
     const endAtValue = hasEndAt && endAt ? new Date(endAt).toISOString() : null;
-    const { data: savedGoal, error } = await supabase
-      .from("goals")
-      .insert({
-        user_id: session.user.id,
-        title: title.trim(),
-        created_at: createdAt,
-        end_at: endAtValue,
-      })
-      .select("id, title, outcome, created_at, end_at")
-      .single();
+    const { data: result, error } = await createGoal({
+      userId: session.user.id,
+      title: title.trim(),
+      createdAt,
+      endAt: endAtValue,
+      categoryIds: selectedCategories,
+      categoryNames: categories
+        .filter((category) => selectedCategories.includes(category.id))
+        .map((category) => category.name),
+      linkCategories: categoriesFromDb,
+    });
 
-    if (error || !savedGoal) {
-      setGoalsError(error?.message ?? "Unable to save goal.");
-      pushToast(error?.message ?? "Unable to save goal.", "error");
+    if (error || !result) {
+      setGoalsError(error ?? "Unable to save goal.");
+      pushToast(error ?? "Unable to save goal.", "error");
       return;
     }
 
-    if (categoriesFromDb && selectedCategories.length > 0) {
-      const { error: categoryError } = await supabase
-        .from("goal_categories")
-        .insert(
-          selectedCategories.map((categoryId) => ({
-            goal_id: savedGoal.id,
-            category_id: categoryId,
-          })),
-        );
-      if (categoryError) {
-        setGoalsError(categoryError.message);
-        pushToast(categoryError.message, "error");
-      }
-    }
-
-    const categoryNames = categories
-      .filter((category) => selectedCategories.includes(category.id))
-      .map((category) => category.name);
-
-    const newGoal: Goal = {
-      id: savedGoal.id,
-      title: savedGoal.title,
-      createdAt: savedGoal.created_at,
-      endAt: savedGoal.end_at ?? undefined,
-      categories: categoryNames,
-    };
-
-    setGoals((current) => [newGoal, ...current]);
+    setGoals((current) => [result.goal, ...current]);
     resetForm();
     setSaveNotice("Goal saved.");
-    pushToast("Goal created.", "success");
+
+    if (result.categoriesLinked) {
+      pushToast("Goal created.", "success");
+    } else {
+      setGoalsError(result.categoryError);
+      pushToast("Goal created, but its tags could not be saved.", "error");
+    }
   };
 
   const orderedGoals = useMemo(() => goals, [goals]);
@@ -513,13 +431,10 @@ export default function Home() {
       return;
     }
 
-    const { error } = await supabase
-      .from("goals")
-      .update({ outcome: nextOutcome })
-      .eq("id", goalId);
+    const { error } = await setGoalOutcome(goalId, nextOutcome);
 
     if (error) {
-      setGoalsError(error.message);
+      setGoalsError(error);
       return;
     }
 
@@ -578,55 +493,27 @@ export default function Home() {
 
     const endAtValue = editHasEndAt && editEndAt ? new Date(editEndAt).toISOString() : null;
 
-    const { error } = await supabase
-      .from("goals")
-      .update({
-        title: editTitle.trim(),
-        outcome: editOutcome,
-        end_at: endAtValue,
-      })
-      .eq("id", editGoal.id);
+    const { data: result, error } = await updateGoal({
+      goalId: editGoal.id,
+      title: editTitle.trim(),
+      outcome: editOutcome,
+      endAt: endAtValue,
+      categoryIds: editSelectedCategories,
+      syncCategories: categoriesFromDb,
+    });
 
-    if (error) {
-      setGoalsError(error.message);
-      pushToast(error.message, "error");
+    if (error || !result) {
+      setGoalsError(error ?? "Unable to update goal.");
+      pushToast(error ?? "Unable to update goal.", "error");
       setEditSaving(false);
       return;
     }
 
-    if (categoriesFromDb) {
-      const { error: deleteError } = await supabase
-        .from("goal_categories")
-        .delete()
-        .eq("goal_id", editGoal.id);
-      if (deleteError) {
-        setGoalsError(deleteError.message);
-        pushToast(deleteError.message, "error");
-        setEditSaving(false);
-        return;
-      }
-
-      if (editSelectedCategories.length > 0) {
-        const { error: insertError } = await supabase
-          .from("goal_categories")
-          .insert(
-            editSelectedCategories.map((categoryId) => ({
-              goal_id: editGoal.id,
-              category_id: categoryId,
-            })),
-          );
-        if (insertError) {
-          setGoalsError(insertError.message);
-          pushToast(insertError.message, "error");
-          setEditSaving(false);
-          return;
-        }
-      }
-    }
-
-    const updatedCategoryNames = categories
-      .filter((category) => editSelectedCategories.includes(category.id))
-      .map((category) => category.name);
+    const updatedCategoryNames = result.categoriesLinked
+      ? categories
+          .filter((category) => editSelectedCategories.includes(category.id))
+          .map((category) => category.name)
+      : [];
 
     setGoals((current) =>
       current.map((goal) =>
@@ -637,14 +524,20 @@ export default function Home() {
               outcome: editOutcome ?? undefined,
               endAt: endAtValue ?? undefined,
               categories: updatedCategoryNames,
-              categoryIds: editSelectedCategories,
+              categoryIds: result.categoriesLinked ? editSelectedCategories : [],
             }
           : goal,
       ),
     );
 
     setEditSaving(false);
-    pushToast("Goal updated.", "success");
+
+    if (result.categoriesLinked) {
+      pushToast("Goal updated.", "success");
+    } else {
+      setGoalsError(result.categoryError);
+      pushToast("Goal updated, but its tags could not be saved.", "error");
+    }
   };
 
   const handleDeleteGoal = async () => {
@@ -654,10 +547,10 @@ export default function Home() {
     }
     setEditDeleting(true);
     setGoalsError(null);
-    const { error } = await supabase.from("goals").delete().eq("id", editGoal.id);
+    const { error } = await deleteGoal(editGoal.id);
     if (error) {
-      setGoalsError(error.message);
-      pushToast(error.message, "error");
+      setGoalsError(error);
+      pushToast(error, "error");
       setEditDeleting(false);
       return;
     }

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -17,7 +17,14 @@ import {
 import { Input } from "@/components/ui/input";
 import { supabase } from "@/lib/supabaseClient";
 import type { Category } from "@/lib/types";
-import { DEFAULT_TAG_SEED, normalizeTag, toTagId } from "@/lib/tags";
+import {
+  createTag,
+  deleteTag,
+  fetchTagsForUser,
+  normalizeTag,
+  toTagId,
+  updateTag,
+} from "@/lib/tags";
 
 const TAG_HIGHLIGHT_DURATION = 2400;
 
@@ -98,54 +105,17 @@ function TagsPageContent() {
       }
 
       setCategoriesLoaded(false);
-      const { data, error: loadError } = await supabase
-        .from("categories")
-        .select("id, name, description, user_id")
-        .eq("user_id", userId)
-        .order("name");
+      const { data, error: loadError } = await fetchTagsForUser(userId);
 
-      if (loadError) {
-        setError(loadError.message);
+      if (loadError || !data) {
+        setError(loadError ?? "Unable to load tags.");
         setLoading(false);
         setCategoriesFromDb(false);
         setCategoriesLoaded(true);
         return;
       }
 
-      if (!data || data.length === 0) {
-        const { data: defaults } = await supabase
-          .from("categories")
-          .select("name, description")
-          .is("user_id", null)
-          .order("name");
-
-        const seed =
-          defaults && defaults.length > 0 ? defaults : DEFAULT_TAG_SEED;
-
-        if (seed.length > 0) {
-          await supabase.from("categories").insert(
-            seed.map((item) => ({
-              user_id: userId,
-              name: item.name,
-              description: item.description ?? null,
-            })),
-          );
-        }
-
-        const { data: reloaded } = await supabase
-          .from("categories")
-          .select("id, name, description, user_id")
-          .eq("user_id", userId)
-          .order("name");
-        setCategories((reloaded ?? []) as Category[]);
-        setCategoriesFromDb(true);
-        setCategoriesUserId(userId);
-        setCategoriesLoaded(true);
-        setLoading(false);
-        return;
-      }
-
-      setCategories(data as Category[]);
+      setCategories(data);
       setCategoriesFromDb(true);
       setCategoriesUserId(userId);
       setCategoriesLoaded(true);
@@ -179,22 +149,18 @@ function TagsPageContent() {
       return;
     }
     closeCreateDialog();
-    const { data, error: insertError } = await supabase
-      .from("categories")
-      .insert({
-        user_id: userId,
-        name,
-        description: newDescription.trim() || null,
-      })
-      .select("id, name, description")
-      .single();
+    const { data, error: insertError } = await createTag({
+      userId,
+      name,
+      description: newDescription.trim() || null,
+    });
     if (insertError || !data) {
-      setError(insertError?.message ?? "Unable to create tag.");
-      pushToast(insertError?.message ?? "Unable to create tag.", "error");
+      setError(insertError ?? "Unable to create tag.");
+      pushToast(insertError ?? "Unable to create tag.", "error");
       return;
     }
     setCategories((current) =>
-      [...current, data as Category].sort((a, b) => a.name.localeCompare(b.name)),
+      [...current, data].sort((a, b) => a.name.localeCompare(b.name)),
     );
     setCategoriesFromDb(true);
     setNewName("");
@@ -205,16 +171,10 @@ function TagsPageContent() {
   const handleUpdate = async (tag: Category) => {
     if (!supabase) return;
     setError(null);
-    const { error: updateError } = await supabase
-      .from("categories")
-      .update({
-        name: tag.name.trim(),
-        description: tag.description?.trim() || null,
-      })
-      .eq("id", tag.id);
+    const { error: updateError } = await updateTag(tag);
     if (updateError) {
-      setError(updateError.message);
-      pushToast(updateError.message, "error");
+      setError(updateError);
+      pushToast(updateError, "error");
       return;
     }
     pushToast("Tag updated.", "success");
@@ -224,13 +184,10 @@ function TagsPageContent() {
     if (!supabase) return;
     if (!window.confirm("Delete this tag?")) return;
     setError(null);
-    const { error: deleteError } = await supabase
-      .from("categories")
-      .delete()
-      .eq("id", tagId);
+    const { error: deleteError } = await deleteTag(tagId);
     if (deleteError) {
-      setError(deleteError.message);
-      pushToast(deleteError.message, "error");
+      setError(deleteError);
+      pushToast(deleteError, "error");
       return;
     }
     setCategories((current) => current.filter((tag) => tag.id !== tagId));

--- a/lib/goals.ts
+++ b/lib/goals.ts
@@ -1,0 +1,193 @@
+import { supabase } from "@/lib/supabaseClient";
+import type { DataResult, Goal } from "@/lib/types";
+
+/**
+ * Goals and their tag links are two writes with no transaction around them.
+ * When the goal lands but the links do not, the goal is real and kept, and
+ * `categoriesLinked: false` tells the caller not to claim the tags stuck —
+ * so local state can match what is actually in the database.
+ */
+export type CategorySyncResult = {
+  categoriesLinked: boolean;
+  categoryError: string | null;
+};
+
+const GOAL_SELECT =
+  "id, title, outcome, created_at, end_at, goal_categories(category_id, categories(name))";
+
+const NO_CLIENT = "Supabase is not configured.";
+
+type GoalCategoryRow = {
+  category_id?: string | null;
+  categories?: { name?: string } | { name?: string }[] | null;
+};
+
+type GoalRow = {
+  id: string;
+  title: string;
+  outcome?: "passed" | "failed" | null;
+  created_at: string;
+  end_at?: string | null;
+  goal_categories?: GoalCategoryRow[] | null;
+};
+
+const categoryNameOf = (row: GoalCategoryRow): string | null => {
+  const categories = row.categories;
+  if (!categories) return null;
+  if (Array.isArray(categories)) return categories[0]?.name ?? null;
+  return categories.name ?? null;
+};
+
+export const mapGoalRow = (row: GoalRow): Goal => ({
+  id: row.id,
+  title: row.title,
+  outcome: row.outcome ?? undefined,
+  createdAt: row.created_at,
+  endAt: row.end_at ?? undefined,
+  categoryIds: (row.goal_categories ?? [])
+    .map((item) => item.category_id)
+    .filter((id): id is string => typeof id === "string"),
+  categories: (row.goal_categories ?? [])
+    .map(categoryNameOf)
+    .filter((name): name is string => typeof name === "string"),
+});
+
+export async function fetchGoals(): Promise<DataResult<Goal[]>> {
+  if (!supabase) return { data: null, error: NO_CLIENT };
+
+  const { data, error } = await supabase
+    .from("goals")
+    .select(GOAL_SELECT)
+    .order("created_at", { ascending: false });
+
+  if (error || !data) {
+    return { data: null, error: error?.message ?? "Unable to load goals." };
+  }
+
+  return { data: (data as GoalRow[]).map(mapGoalRow), error: null };
+}
+
+async function linkCategories(goalId: string, categoryIds: string[]) {
+  if (!supabase || categoryIds.length === 0) return null;
+  const { error } = await supabase.from("goal_categories").insert(
+    categoryIds.map((categoryId) => ({
+      goal_id: goalId,
+      category_id: categoryId,
+    })),
+  );
+  return error?.message ?? null;
+}
+
+export async function createGoal(params: {
+  userId: string;
+  title: string;
+  createdAt: string;
+  endAt: string | null;
+  categoryIds: string[];
+  categoryNames: string[];
+  linkCategories: boolean;
+}): Promise<DataResult<CategorySyncResult & { goal: Goal }>> {
+  if (!supabase) return { data: null, error: NO_CLIENT };
+
+  const { data: savedGoal, error } = await supabase
+    .from("goals")
+    .insert({
+      user_id: params.userId,
+      title: params.title,
+      created_at: params.createdAt,
+      end_at: params.endAt,
+    })
+    .select("id, title, outcome, created_at, end_at")
+    .single();
+
+  if (error || !savedGoal) {
+    return { data: null, error: error?.message ?? "Unable to save goal." };
+  }
+
+  const categoryError = params.linkCategories
+    ? await linkCategories(savedGoal.id, params.categoryIds)
+    : null;
+  const categoriesLinked = categoryError === null;
+
+  return {
+    data: {
+      goal: {
+        id: savedGoal.id,
+        title: savedGoal.title,
+        createdAt: savedGoal.created_at,
+        endAt: savedGoal.end_at ?? undefined,
+        // Only claim the tags if they actually landed.
+        categories: categoriesLinked ? params.categoryNames : [],
+        categoryIds: categoriesLinked ? params.categoryIds : [],
+      },
+      categoriesLinked,
+      categoryError,
+    },
+    error: null,
+  };
+}
+
+export async function updateGoal(params: {
+  goalId: string;
+  title: string;
+  outcome: "passed" | "failed" | null;
+  endAt: string | null;
+  categoryIds: string[];
+  syncCategories: boolean;
+}): Promise<DataResult<CategorySyncResult>> {
+  if (!supabase) return { data: null, error: NO_CLIENT };
+
+  const { error } = await supabase
+    .from("goals")
+    .update({
+      title: params.title,
+      outcome: params.outcome,
+      end_at: params.endAt,
+    })
+    .eq("id", params.goalId);
+
+  if (error) return { data: null, error: error.message };
+
+  let categoryError: string | null = null;
+  if (params.syncCategories) {
+    const { error: deleteError } = await supabase
+      .from("goal_categories")
+      .delete()
+      .eq("goal_id", params.goalId);
+
+    // The old links are gone at this point, so any failure from here on means
+    // the goal really does have no tags — report that rather than leaving the
+    // caller showing the previous ones.
+    categoryError =
+      deleteError?.message ??
+      (await linkCategories(params.goalId, params.categoryIds));
+  }
+
+  return {
+    data: { categoriesLinked: categoryError === null, categoryError },
+    error: null,
+  };
+}
+
+export async function setGoalOutcome(
+  goalId: string,
+  outcome: "passed" | "failed",
+): Promise<DataResult<true>> {
+  if (!supabase) return { data: null, error: NO_CLIENT };
+
+  const { error } = await supabase
+    .from("goals")
+    .update({ outcome })
+    .eq("id", goalId);
+
+  if (error) return { data: null, error: error.message };
+  return { data: true, error: null };
+}
+
+export async function deleteGoal(goalId: string): Promise<DataResult<true>> {
+  if (!supabase) return { data: null, error: NO_CLIENT };
+
+  const { error } = await supabase.from("goals").delete().eq("id", goalId);
+  if (error) return { data: null, error: error.message };
+  return { data: true, error: null };
+}

--- a/lib/tags.ts
+++ b/lib/tags.ts
@@ -1,4 +1,8 @@
-import type { Category } from "@/lib/types";
+import { supabase } from "@/lib/supabaseClient";
+import type { Category, DataResult } from "@/lib/types";
+
+const NO_CLIENT = "Supabase is not configured.";
+const TAG_SELECT = "id, name, description, user_id";
 
 export const normalizeTag = (value: string) => value.trim().toLowerCase();
 
@@ -29,3 +33,101 @@ export const DEFAULT_TAG_SEED = DEFAULT_TAG_NAMES.map((name) => ({
   name,
   description: null,
 }));
+
+const selectTagsFor = async (userId: string) => {
+  if (!supabase) return null;
+  const { data } = await supabase
+    .from("categories")
+    .select(TAG_SELECT)
+    .eq("user_id", userId)
+    .order("name");
+  return (data ?? null) as Category[] | null;
+};
+
+/**
+ * Loads a user's tags, seeding them on first use. A brand-new account has no
+ * rows, so we copy the shared defaults (`user_id is null`) into their own set,
+ * falling back to the built-in list when the database has no defaults either.
+ */
+export async function fetchTagsForUser(
+  userId: string,
+): Promise<DataResult<Category[]>> {
+  if (!supabase) return { data: null, error: NO_CLIENT };
+
+  const { data, error } = await supabase
+    .from("categories")
+    .select(TAG_SELECT)
+    .eq("user_id", userId)
+    .order("name");
+
+  if (error) return { data: null, error: error.message };
+  if (data && data.length > 0) {
+    return { data: data as Category[], error: null };
+  }
+
+  const { data: defaults } = await supabase
+    .from("categories")
+    .select("name, description")
+    .is("user_id", null)
+    .order("name");
+
+  const seed = defaults && defaults.length > 0 ? defaults : DEFAULT_TAG_SEED;
+
+  if (seed.length > 0) {
+    await supabase.from("categories").insert(
+      seed.map((item) => ({
+        user_id: userId,
+        name: item.name,
+        description: item.description ?? null,
+      })),
+    );
+  }
+
+  return { data: (await selectTagsFor(userId)) ?? [], error: null };
+}
+
+export async function createTag(params: {
+  userId: string;
+  name: string;
+  description: string | null;
+}): Promise<DataResult<Category>> {
+  if (!supabase) return { data: null, error: NO_CLIENT };
+
+  const { data, error } = await supabase
+    .from("categories")
+    .insert({
+      user_id: params.userId,
+      name: params.name,
+      description: params.description,
+    })
+    .select("id, name, description")
+    .single();
+
+  if (error || !data) {
+    return { data: null, error: error?.message ?? "Unable to create tag." };
+  }
+  return { data: data as Category, error: null };
+}
+
+export async function updateTag(tag: Category): Promise<DataResult<true>> {
+  if (!supabase) return { data: null, error: NO_CLIENT };
+
+  const { error } = await supabase
+    .from("categories")
+    .update({
+      name: tag.name.trim(),
+      description: tag.description?.trim() || null,
+    })
+    .eq("id", tag.id);
+
+  if (error) return { data: null, error: error.message };
+  return { data: true, error: null };
+}
+
+export async function deleteTag(tagId: string): Promise<DataResult<true>> {
+  if (!supabase) return { data: null, error: NO_CLIENT };
+
+  const { error } = await supabase.from("categories").delete().eq("id", tagId);
+  if (error) return { data: null, error: error.message };
+  return { data: true, error: null };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -13,3 +13,8 @@ export type Category = {
   name: string;
   description?: string | null;
 };
+
+/** Outcome of a data-layer call: either data, or a message safe to surface. */
+export type DataResult<T> =
+  | { data: T; error: null }
+  | { data: null; error: string };


### PR DESCRIPTION
Every Supabase read and write for goals and tags now lives behind named functions returning a DataResult<T>, instead of query builders inline in the two page components:

- lib/goals.ts  fetchGoals, createGoal, updateGoal, setGoalOutcome, deleteGoal, mapGoalRow
- lib/tags.ts   fetchTagsForUser, createTag, updateTag, deleteTag

The load-and-seed routine for a new user's tags was written out three times across the two pages; fetchTagsForUser is now the single copy. mapGoalRow likewise replaces the inline flattening of the nested goal_categories join.

Fixes the tag-link drift on partial writes. A goal and its tag links are two statements with no transaction around them, so the link write can fail after the goal has already been committed. Previously the UI added the goal with its tags shown regardless, and on update it kept displaying the old tags after the delete had already removed them — in both cases the screen claimed tags the database did not have, until the next reload silently dropped them.

createGoal and updateGoal now return categoriesLinked, and the pages render tags only when the links actually landed, with a toast that says the goal saved but its tags did not. No goal is ever discarded to achieve this. A real fix needs both statements in one transaction (a Postgres function); this makes the existing behaviour honest rather than papering over it.

DataResult moves to lib/types.ts so lib/tags.ts need not import lib/goals.ts.

Adds 9 tests covering the join mapping and both partial-write paths. 37 tests pass; page.tsx 1653 -> 1546 lines, tags/page.tsx 463 -> 420.